### PR TITLE
fix: allow for nullable property access

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ identifiers, operators, property access, method and function calls, and
 literals (including arrays and objects), and pipes.
 
 Example:
+
 ```js
-person.title + " " + person.getFullName() | uppercase
+(person.title + ' ' + person.getFullName()) | uppercase;
 ```
 
 ## Usage

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  * @license
  * Portions Copyright (c) 2013, the Dart project authors.
  */

--- a/src/lib/ast_factory.ts
+++ b/src/lib/ast_factory.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  * @license
  * Portions Copyright (c) 2013, the Dart project authors.
  */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  * @license
  * Portions Copyright (c) 2013, the Dart project authors.
  */

--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  * @license
  * Portions Copyright (c) 2013, the Dart project authors.
  */
@@ -189,7 +189,7 @@ export class EvalAstFactory implements AstFactory<Expression> {
       receiver: g,
       name: n,
       evaluate(scope) {
-        return this.receiver.evaluate(scope)[this.name];
+        return this.receiver.evaluate(scope)?.[this.name];
       },
       getIds(idents) {
         this.receiver.getIds(idents);
@@ -236,7 +236,7 @@ export class EvalAstFactory implements AstFactory<Expression> {
       receiver: e,
       argument: a,
       evaluate(scope) {
-        return this.receiver.evaluate(scope)[this.argument.evaluate(scope)];
+        return this.receiver.evaluate(scope)?.[this.argument.evaluate(scope)];
       },
       getIds(idents) {
         this.receiver.getIds(idents);

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -13,11 +13,11 @@ import {
 } from './constants.js';
 import {Kind, Token, Tokenizer} from './tokenizer.js';
 
-export function parse(
+export function parse<E extends Expression>(
   expr: string,
-  astFactory: AstFactory<Expression>
-): Expression | undefined {
-  return new Parser(expr, astFactory).parse();
+  astFactory: AstFactory<E>
+): E | undefined {
+  return new Parser<E>(expr, astFactory).parse();
 }
 
 export class Parser<N extends Expression> {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,9 +1,9 @@
-/* 
+/*
  * @license
  * Portions Copyright (c) 2013, the Dart project authors.
  */
 
-import {ID, Invoke, Expression} from './ast.js';
+import {ID, Invoke, Expression, Literal} from './ast.js';
 import {AstFactory} from './ast_factory.js';
 import {
   BINARY_OPERATORS,

--- a/src/lib/tokenizer.ts
+++ b/src/lib/tokenizer.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  * @license
  * Portions Copyright (c) 2013, the Dart project authors.
  */

--- a/src/test/eval_test.ts
+++ b/src/test/eval_test.ts
@@ -64,6 +64,17 @@ suite('eval', function () {
     expectEval('{"a": 1}.a', 1);
   });
 
+  test('should return undefined for deeply nil properties of the scope', function () {
+    expectEval('data.nullable', undefined, {});
+    expectEval('data.nullable', undefined, {data: null});
+    expectEval('data.nullable.nulled', undefined, {data: null});
+    expectEval('data.nullable.nulled.right', undefined, {data: null});
+    // test the opposite case
+    expectEval('data.nonnullable.nonnulled.right', true, {
+      data: {nonnullable: {nonnulled: {right: true}}},
+    });
+  });
+
   test('should evaluate unary operators', function () {
     expectEval('+a', 2, {a: 2});
     expectEval('-a', -2, {a: 2});


### PR DESCRIPTION
## What I Did:

- Use `?.` optional chaining to access the results of `this.receiver.evaluate()`
- update the type of `parse` to take a type instance of `Expression`
- ran prettier

fixes #1 