### PR TITLE
Use optional-chaining in method calls

### DIFF
--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -215,10 +215,10 @@ export class EvalAstFactory implements AstFactory<Expression> {
         // invoking a top-level function rather than a method. If method is
         // defined on a nested scope, then we should probably set _this to null.
         const _this = this.method ? receiver : scope['this'] ?? scope;
-        const f = this.method ? receiver[method] : receiver;
+        const f = this.method ? receiver?.[method] : receiver;
         const args = this.arguments ?? [];
         const argValues = args.map((a) => a?.evaluate(scope));
-        return f.apply(_this, argValues);
+        return f?.apply?.(_this, argValues);
       },
       getIds(idents) {
         this.receiver.getIds(idents);

--- a/src/test/eval_test.ts
+++ b/src/test/eval_test.ts
@@ -215,4 +215,14 @@ suite('eval', function () {
     expectEval('name.substring(2)', foo.name.substring(2), foo);
     expectEval('a()()', 1, foo);
   });
+
+  test('should not error on undefined methods', function () {
+    const foo = {
+      name: 'fred',
+    };
+    expectEval('x()', undefined, foo);
+    expectEval('x().toString()', undefined, foo);
+    expectEval('x(name)', undefined, foo);
+    expectEval('x()()', undefined, foo);
+  });
 });


### PR DESCRIPTION
Prevents errors when calling undefined functions in expressions

Fixes #8