### PR TITLE
Support Unicode identifiers

### DIFF
--- a/src/benchmark/parse_benchmark.ts
+++ b/src/benchmark/parse_benchmark.ts
@@ -9,6 +9,12 @@ suite
   .add('parse identifier', function () {
     return parse('foo', astFactory);
   })
+  .add('parse ascii identifier', function () {
+    return parse('hello + world + id + index + identifier', astFactory);
+  })
+  .add('parse unicode identifier', function () {
+    return parse('你好 + Привет + こんにちは + 안녕하세요 + Γειά', astFactory);
+  })
   .add('parse complex', function () {
     return parse('(a + b([1, 2, 3]) * c)', astFactory);
   })

--- a/src/lib/tokenizer.ts
+++ b/src/lib/tokenizer.ts
@@ -40,18 +40,22 @@ const _isWhitespace = (ch: number) =>
   ch === 13 /* \r */ ||
   ch === 32; /* space */
 
-// TODO(justinfagnani): allow code points > 127
+const REGEXP_ID_START = /\p{ID_Start}/u;
 const _isIdentOrKeywordStart = (ch: number) =>
-  ch === 95 /* _ */ ||
-  ch === 36 /* $ */ ||
-  // ch &= ~32 puts ch into the range [65,90] [A-Z] only if ch was already in
-  // the that range or in the range [97,122] [a-z]. We must mutate ch only after
-  // checking other characters, thus the comma operator.
-  ((ch &= ~32), 65 /* A */ <= ch && ch <= 90); /* Z */
+  ch < 127
+    ? ch === 95 /* _ */ ||
+      ch === 36 /* $ */ ||
+      ((ch &= ~32), 65 /* A */ <= ch && ch <= 90) /* Z */
+    : REGEXP_ID_START.test(String.fromCharCode(ch));
 
-// TODO(justinfagnani): allow code points > 127
+const REGEXP_ID_CONTINUE = /\p{ID_Continue}/u;
 const _isIdentifier = (ch: number) =>
-  _isIdentOrKeywordStart(ch) || _isNumber(ch);
+  ch <= 127
+    ? ch === 95 /* _ */ ||
+      ch === 36 /* $ */ ||
+      _isNumber(ch) ||
+      ((ch &= ~32), 65 /* A */ <= ch && ch <= 90) /* Z */
+    : REGEXP_ID_CONTINUE.test(String.fromCharCode(ch));
 
 const _isKeyword = (str: string) => KEYWORDS.indexOf(str) !== -1;
 
@@ -116,7 +120,7 @@ export class Tokenizer {
       this._advance(true);
     }
     if (_isQuote(this._next!)) return this._tokenizeString();
-    if (_isIdentOrKeywordStart(this._next!)) {
+    if (this._next && _isIdentOrKeywordStart(this._next)) {
       return this._tokenizeIdentOrKeyword();
     }
     if (_isNumber(this._next!)) return this._tokenizeNumber();
@@ -179,7 +183,7 @@ export class Tokenizer {
     // be called if _isIdentOrKeywordStart(this._next!) has returned true.
     do {
       this._advance();
-    } while (_isIdentifier(this._next!));
+    } while (this._next && _isIdentifier(this._next));
     const value = this._getValue();
     const kind = _isKeyword(value) ? Kind.KEYWORD : Kind.IDENTIFIER;
     return token(kind, value);

--- a/src/test/tokenizer_test.ts
+++ b/src/test/tokenizer_test.ts
@@ -50,6 +50,15 @@ suite('tokenizer', function () {
     expectTokens('$abc', [t(IDENTIFIER, '$abc')]);
     expectTokens('a$', [t(IDENTIFIER, 'a$')]);
     expectTokens('a1', [t(IDENTIFIER, 'a1')]);
+
+    expectTokens('你好', [t(IDENTIFIER, '你好')]);
+    expectTokens('مرحبًا', [t(IDENTIFIER, 'مرحبًا')]);
+    expectTokens('hello', [t(IDENTIFIER, 'hello')]);
+    expectTokens('Привет', [t(IDENTIFIER, 'Привет')]);
+    expectTokens('こんにちは', [t(IDENTIFIER, 'こんにちは')]);
+    expectTokens('안녕하세요', [t(IDENTIFIER, '안녕하세요')]);
+    expectTokens('Γειά', [t(IDENTIFIER, 'Γειά')]);
+    expectTokens('שלום', [t(IDENTIFIER, 'שלום')]);
   });
 
   test('should tokenize two identifiers', function () {


### PR DESCRIPTION
## Description

For characters with a code point greater than 127, use the regular expressions `/\p{ID_Start}/u` and `/\p{ID_Continue}/u` to check whether they are valid identifier characters.

## Benchmark

Before:

```
parse identifier x 6,382,322 ops/sec ±0.55% (88 runs sampled)
parse ascii identifier x 787,256 ops/sec ±0.44% (91 runs sampled)
parse unicode identifier: 
parse complex x 514,853 ops/sec ±0.45% (90 runs sampled)
```

After:

```
parse identifier x 6,844,745 ops/sec ±0.67% (90 runs sampled)
parse ascii identifier x 846,707 ops/sec ±0.29% (98 runs sampled)
parse unicode identifier x 460,353 ops/sec ±0.50% (94 runs sampled)
parse complex x 527,403 ops/sec ±0.23% (95 runs sampled)
```